### PR TITLE
Add ability to blacklist certain buffers from highlight update + Massive code refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,23 @@
 highlight-global
 ================
 
-A highlight package for EMACS across all buffers. Unlike
-[highlight-symobl](https://github.com/nschum/highlight-symbol.el)
-which only do highlighting in current buffer, this package highlights
-all matches accross ALL buffer. Multiple highlights are
-supported. Different highlight shows in different faces.
+A highlight package for EMACS across all buffers.
+
+Unlike [`highlight-symbol`](https://github.com/nschum/highlight-symbol.el) which only does highlighting in the current buffer, this package highlights all matches across ALL buffers. Multiple highlights are supported. Different highlights show in different faces.
 
 There are 2 ways to select a highlight target:
-1. Mark the selection by region(very usful when you want to highlight a pattern accross all symbols),
+
+1. Mark the selection by region (very usful when you want to highlight a pattern accross all symbols).
 2. Put cursor on a symbol to pick the symbol to highlight.
 
-Once you have chosen a highlight target, you can call *highlight-frame-toggle* to highlit/unhighlight the target. You could bind a key like this:
+Once you have chosen a highlight target, you can call `highlight-global-hl-frame-toggle` to highlight/unhighlight the target. You could bind a key like this:
+
 ``` lisp
-(global-set-key (kbd "M-H") 'highlight-frame-toggle)
+(global-set-key (kbd "M-H") #'highlight-global-hl-frame-toggle)
 ```
 
-You could have highlighted multiple targets with different faces, but
-you want to clear all the highlights since you do not need them
-anymore. You could select the highlighted target one by one, then call
-*highlight-frame-toggle* on each of them. Or you could just call
-*clear-highlight-frame* which will unhighlights all highlighted
-target. You could bind it to a key as follows:
+You could have highlighted multiple targets with different faces, but you want to clear all the highlights since you do not need them anymore. You could select the highlighted target one by one, then call `highlight-global-hl-frame-toggle` on each of them. Or you could just call `highlight-global-clear-hl-frame` which will unhighlight all highlighted target. You could bind it to a key as follows:
 
 ``` lisp
-(global-set-key (kbd "M-+") 'clear-highlight-frame)
+(global-set-key (kbd "M-+") #'highlight-global-clear-hl-frame)
 ```

--- a/highlight-global.el
+++ b/highlight-global.el
@@ -1,4 +1,4 @@
-;;; highlight-global.el --- package for highlighting multi symbols accross ALL buffers
+;;; highlight-global.el --- package for highlighting multi symbols across ALL buffers
 
 ;; Copyright 2013-2014 Glen Dai
 ;; Author: Glen Dai <gafglen@gmail.com>
@@ -21,38 +21,39 @@
 
 ;;; Commentary:
 
-;; When reading source code with EMACS, couples of related files will
+;; When reading source code with EMACS, couple of related files will
 ;; be opened simultaneously. A function/variable defined in one file
 ;; will be referenced by another function in another file. A
 ;; highlight of the corresponding function/variable across these
 ;; buffers will make code reading much more friendly.
 
-;; EMACS support multi highlight symbols in one buffer but not
-;; accross multi buffers. This package provide highlighting of
-;; symbols accross all buffer.
+;; EMACS support multiple highlight symbols in one buffer but not
+;; across multiple buffers. This package provide highlighting of
+;; symbols across all buffers.
 
-;; When new highlight is being added, only the windows of current
-;; frame are updated. Whenever frame configration change(say new
-;; window is added to current frame), window's highlight will be
-;; updated to make windows currently showing always has the updated
-;; highlights. This way is much more effecient than iterating the
-;; overall buffer-list to update highlights for every buffer.
+;; When a new highlight is added, only the windows of the current
+;; frame are updated. Whenever frame configuration changes (say a new
+;; window is added to the current frame), the highlights will be
+;; updated to make the windows always show the updated highlights.
+;; This way, it is much more efficient than iterating through the
+;; whole buffer list to update highlights for every buffer (even the ones which
+;; are not visible).
 ;;
-;; Multi symbols can be highlighted simultaneously. Different
+;; Multiple symbols can be highlighted simultaneously. Different
 ;; highlights have different face. You could add your highlight face
 ;; to `highlight-global-hl-faces'.
 
 ;;; How to use?
 
-;; Put the package into load-path, and load the packaget
+;; Put the package in `load-path', and load the package:
 ;;     (require 'highlight-global)
 
 ;; Toggle highlight of current region (or symbol under cursor if
 ;; region is not active) and bind it like this:
-;;     (global-set-key (kbd "M-H") 'highlight-global-hl-frame-toggle)
+;;     (global-set-key (kbd "M-H") #'highlight-global-hl-frame-toggle)
 
-;; Clear all highlight of current frame, and bind it like this:
-;;     (global-set-key (kbd "M-C") 'highlight-global-clear-hl-frame)
+;; Clear all highlights from the current frame, and bind it like this:
+;;     (global-set-key (kbd "M-C") #'highlight-global-clear-hl-frame)
 
 
 (require 'hi-lock)

--- a/highlight-global.el
+++ b/highlight-global.el
@@ -65,11 +65,14 @@
     ('hi-blue   . 0))
   "Default faces for hi-lock interactive functions, you could add your own.")
 
-(defvar highlight-global-blacklist-buffers
-  '("*Colors*" ; M-x list-colors-display
-    "*LV*" ; hydra package
-    "*which-key*") ; which-key package
-  "List of buffers in which the highlight should not be updated.")
+(defvar highlight-global-blacklist-buffers-regexp
+  (concat "\\("
+          "\\*Colors\\*" ; M-x list-colors-display
+          "\\|\\*LV\\*" ; hydra package
+          "\\|\\*which\\-key\\*" ; which-key package
+          "\\|\\*Minibuf\\-[0-9]+\\*" ; Recursive minibuffers
+          "\\)")
+  "Regexp of buffer names in which the highlight should not be updated.")
 
 ;; List to store what had been highlighted
 (defvar highlight-global-hl-list nil
@@ -231,8 +234,10 @@ If active region, get region, else get symbol under cursor."
                             "\\(^[[:space:]\n]*\\|[[:space:]\n]*$\\)" ""
                             (buffer-name))))
                       ;; (message "Window: %s Buffer: %s" win buf-name-chomp)
-                      (when (not (member buf-name-chomp
-                                         highlight-global-blacklist-buffers))
+                      (when (not
+                             (string-match-p highlight-global-blacklist-buffers-regexp
+                                             buf-name-chomp))
+                        ;; (message "Updating highlights in buffer: %s" buf-name-chomp)
                         (highlight-global-update-current-buffer-hl)))))))
 
 (defun highlight-global-update-hl-fixup (frame)

--- a/highlight-global.el
+++ b/highlight-global.el
@@ -65,12 +65,13 @@
     ('hi-blue   . 0))
   "Default faces for hi-lock interactive functions, you could add your own.")
 
-(defvar highlight-global-blacklist-buffers-regexp
+(defconst highlight-global-blacklist-buffers-regexp
   (concat "\\("
           "\\*Colors\\*" ; M-x list-colors-display
           "\\|\\*LV\\*" ; hydra package
           "\\|\\*which\\-key\\*" ; which-key package
           "\\|\\*Minibuf\\-[0-9]+\\*" ; Recursive minibuffers
+          "\\|\\*Help\\*" ; Help
           "\\)")
   "Regexp of buffer names in which the highlight should not be updated.")
 

--- a/highlight-global.el
+++ b/highlight-global.el
@@ -24,7 +24,7 @@
 ;; When reading source code with EMACS, couples of related files will
 ;; be opened simultaneously. A function/variable defined in one file
 ;; will be referenced by another function in another file. A
-;; highlight of the corresponding function/vairalbe accross these
+;; highlight of the corresponding function/variable across these
 ;; buffers will make code reading much more friendly.
 
 ;; EMACS support multi highlight symbols in one buffer but not
@@ -40,7 +40,7 @@
 ;;
 ;; Multi symbols can be highlighted simultaneously. Different
 ;; highlights have different face. You could add your highlight face
-;; to highlight-faces.
+;; to `highlight-global-hl-faces'.
 
 ;;; How to use?
 
@@ -49,116 +49,111 @@
 
 ;; Toggle highlight of current region (or symbol under cursor if
 ;; region is not active) and bind it like this:
-;;     (global-set-key (kbd "M-H") 'highlight-frame-toggle)
+;;     (global-set-key (kbd "M-H") 'highlight-global-hl-frame-toggle)
 
 ;; Clear all highlight of current frame, and bind it like this:
-;;     (global-set-key (kbd "M-C") 'clear-highlight-frame)
+;;     (global-set-key (kbd "M-C") 'highlight-global-clear-hl-frame)
 
 
 (require 'hi-lock)
-(setq hi-lock-file-patterns-policy 'never)
 
-(defvar highlight-faces
+(defvar highlight-global-hl-faces
   '(('hi-yellow . 0)
-    ('hi-pink . 0)
-    ('hi-green . 0)
-    ('hi-blue . 0))
+    ('hi-pink   . 0)
+    ('hi-green  . 0)
+    ('hi-blue   . 0))
   "Default faces for hi-lock interactive functions, you could add your own.")
 
-(defun clear-all-faces ()
+;; List to store what had been highlighted
+(defvar highlight-global-hl-list nil
+  "Global highlight list, always store the updated highlight
+  regexp list, and every item is stored like this
+  ((hilight-str1 . hilight-face1)
+   (hilight-str2 . hilight-face2) ...)")
+
+(defvar highlight-global-hl-list-update-timestamp 0.0
+  "Store the timestamp when `highlight-global-hl-list' was updated.")
+
+(defvar highlight-global-new-unhighlight nil
+  "Stores thing to be unhighlight.")
+
+(defvar highlight-global-new-highlight nil
+  "Stores thing to be highlight.")
+
+(defvar highlight-global--buffer-highlight-list nil
+  "Stores the regexp highlighted by `highlight-global-hl-window' function.")
+(make-variable-buffer-local 'highlight-global--buffer-highlight-list)
+(put 'highlight-global--buffer-highlight-list 'permanent-local t)
+
+;; set it to -0.5 to make sure first time it will update
+(defvar highlight-global--buffer-highlight-list-update-timestamp -0.5
+  "Stores the recently timestamp when `highlight-global--buffer-highlight-list'
+was updated.")
+(make-variable-buffer-local 'highlight-global--buffer-highlight-list-update-timestamp)
+(put 'highlight-global--buffer-highlight-list-update-timestamp 'permanent-local t)
+
+(defun highlight-global--clear-all-faces ()
   "Reset all face's usage count to zero."
-  (dolist (item highlight-faces)
+  (dolist (item highlight-global-hl-faces)
     (setcdr item 0)))
 
-(defun find-and-use-face ()
-  "Find the least used face and increase it, the face will be returned to caller"
-  (let ((least-used-one (nth 0 highlight-faces)))
+(defun highlight-global--find-and-use-face ()
+  "Find the least used face and increase it, the face will be returned to caller."
+  (let ((least-used-one (nth 0 highlight-global-hl-faces)))
     (progn
-      (dolist (face highlight-faces)
+      (dolist (face highlight-global-hl-faces)
         (when (< (cdr face) (cdr least-used-one))
           (setq least-used-one face)))
       (setcdr least-used-one (+ 1 (cdr least-used-one)))
       (car least-used-one))))
 
-(defun release-face (face-to-release)
-  "Release the use of a face by decreasing the counting"
-  (dolist (face highlight-faces)
+(defun highlight-global--release-face (face-to-release)
+  "Release the use of a face by decreasing the count."
+  (dolist (face highlight-global-hl-faces)
     (when (equal (car face) face-to-release)
       (setcdr face (- (cdr face) 1)))))
 
-;; list to store what had been highlighted
-(defvar global-highlight-list nil
-  "Global highlight list, always store the updated highlight
-  regexp list, and every item is stored like this ((hilight-str1
-  . hilight-face1) (hilight-str2 . hilight-face2) ...)")
-
-(defvar global-highlight-list-update-timestamp 0.0
-  "Store the timestamp when `global-highlight-list' was updated")
-
-(defvar new-unhighlight nil "Store's thing to be unhighlight")
-(defvar new-highlight nil "Store's thing to be highlight")
-
-(defvar buffer-highlight-list nil
-  "Stores the regexp highlighed by `highlight-windows' package of
-  current buffer")
-(make-variable-buffer-local 'buffer-highlight-list)
-(put 'buffer-highlight-list 'permanent-local t)
-
-;; set it to -0.5 to make sure first time it will update
-(defvar buffer-highlight-list-update-timestamp -0.5
-  "Stores the recently timestamp when `buffer-highlight-list' was
-  updated")
-(make-variable-buffer-local 'buffer-highlight-list-update-timestamp)
-(put 'buffer-highlight-list-update-timestamp 'permanent-local t)
-
-(defun clear-highlight-window (win)
-  "Clear all highlight of current buffer, called by
-  `unhighlit-windows-all' when iterating all windows. When a
-  buffer is being burry, this funciton also will be called to
-  clear all highlight"
+(defun highlight-global-clear-highlight-window (win)
+  "Clear all highlight of current buffer, called by `unhighlit-windows-all'
+when iterating all windows. When a buffer is being buried, this function also
+will be called to clear all highlight."
   (select-window win)
-  (setq buffer-highlight-list-update-timestamp (float-time))
-  (dolist (item global-highlight-list)
+  (setq highlight-global--buffer-highlight-list-update-timestamp (float-time))
+  (dolist (item highlight-global-hl-list)
     (font-lock-remove-keywords
      nil
      `((,(car item) 0 ,(cdr item) prepend)))
     (font-lock-fontify-buffer)))
 
-(defun clear-highlight-frame ()
-  "Clear all highlights of all windows "
-  (interactive)
-  (walk-windows 'clear-highlight-window)
-  (setq global-highlight-list nil)
-  (clear-all-faces)
-  (setq global-highlight-list-update-timestamp (float-time)))
-
-(defun unhighlight-window (win)
+(defun highlight-global-unhl-window (win)
   "Highligt a buffer, should update of buffer-local
 highlight-list and timestamp, used by `walk-windows'"
   (select-window win)
-  (setq buffer-highlight-list-update-timestamp (float-time))
-  (setq buffer-highlight-list
-        (delete new-unhighlight buffer-highlight-list))
+  (setq highlight-global--buffer-highlight-list-update-timestamp (float-time))
+  (setq highlight-global--buffer-highlight-list
+        (delete highlight-global-new-unhighlight
+                highlight-global--buffer-highlight-list))
   ;; add new highlight to current buffer's keyword list
   (font-lock-remove-keywords
    nil
-   `((,(car new-unhighlight) 0 ,(cdr new-unhighlight) prepend)))
+   `((,(car highlight-global-new-unhighlight)
+      0
+      ,(cdr highlight-global-new-unhighlight) prepend)))
   (font-lock-fontify-buffer))
 
-(defun highlight-window (win)
-  "Highligt a buffer, should update buffer-local highlight-list
-and timestamp"
+(defun highlight-global-hl-window (win)
+  "Highligt a buffer, should update buffer-local highlight-list and timestamp."
   (select-window win)
-  (setq buffer-highlight-list-update-timestamp (float-time))
-  (push new-highlight buffer-highlight-list)
+  (setq highlight-global--buffer-highlight-list-update-timestamp (float-time))
+  (push highlight-global-new-highlight highlight-global--buffer-highlight-list)
   (font-lock-add-keywords
    nil
-   `((,(car new-highlight) 0 ,(cdr new-highlight) prepend)) 'append)
+   `((,(car highlight-global-new-highlight) 0 ,(cdr highlight-global-new-highlight) prepend)) 'append)
   (font-lock-fontify-buffer))
 
-(defun get-thing-to-highlight ()
-  "Get thing to highlight. If active region, get reigon, else get
-symbol under cursor"
+(defun highlight-global-get-thing-to-highlight ()
+  "Get thing to highlight.
+If active region, get region, else get symbol under cursor."
   (if (use-region-p)
       (buffer-substring-no-properties (region-beginning) (region-end))
     (if (thing-at-point 'symbol)
@@ -166,110 +161,118 @@ symbol under cursor"
          (car (bounds-of-thing-at-point 'symbol))
          (cdr (bounds-of-thing-at-point 'symbol))))))
 
-(defun check-whether-highlighted (hi)
-  "Check if HI is already highlighted by checking
-global-highlight-list"
+(defun highlight-global-check-whether-highlighted (hi)
+  "Check if HI is already highlighted by checking `highlight-global-hl-list'."
   (let ((the-found-one nil))
     (progn
-      (dolist (item global-highlight-list)
+      (dolist (item highlight-global-hl-list)
         (when (equal hi (car item))
           (progn
             (setq the-found-one item))))
       the-found-one)))
 
-(defun highlight-frame-toggle ()
+(defun highlight-global-update-current-buffer-hl ()
+  "Update a buffer's highlight to be consistent with global highlight."
+  (if (<= highlight-global--buffer-highlight-list-update-timestamp
+          highlight-global-hl-list-update-timestamp)
+      (if (null highlight-global-hl-list) ; clear buffer
+          ;; 1) global null
+          (progn
+            (dolist (item highlight-global--buffer-highlight-list)
+              (font-lock-remove-keywords
+               nil
+               `((,(car item) 0 ,(cdr item) prepend)))
+              (font-lock-fontify-buffer))
+            (setq highlight-global--buffer-highlight-list-update-timestamp (float-time))
+            (setq highlight-global--buffer-highlight-list nil))
+        ;; 2) global is not null, now update local to global
+        (progn
+          ;; (message "Updating buffer : %s" (current-buffer))
+          ;; 2.1) iterate buffer-list to delete
+          (dolist (item highlight-global--buffer-highlight-list)
+            (if (not (member item highlight-global-hl-list))
+                (progn
+                  (font-lock-remove-keywords
+                   nil
+                   `((,(car item) 0 ,(cdr item) prepend)))
+                  (font-lock-fontify-buffer)
+                  (setq highlight-global--buffer-highlight-list
+                        (delete item highlight-global--buffer-highlight-list)))))
+          ;; 2.2) iterate global-list to add
+          (dolist (item highlight-global-hl-list)
+            (if (not (member item highlight-global--buffer-highlight-list))
+                (progn
+                  (font-lock-add-keywords
+                   nil
+                   `((,(car item) 0 ,(cdr item) prepend)) 'append)
+                  (font-lock-fontify-buffer)
+                  (push item highlight-global--buffer-highlight-list))))
+          (setq highlight-global--buffer-highlight-list-update-timestamp (float-time)))
+        ;; (message "no need to update : %s" (current-buffer))
+        )))
+
+(defun highlight-global-update-hl-fixup (frame)
+  "Automatically update new buffer's highlights when any windows on current
+frame changed. This will make buffers that to be showned because of window
+splitting alway has highlights updated to date."
+  (highlight-global-force-hl-frame))
+
+;; register the on-the-fly highlight-list updating strategy to
+;; window-size-change-functions hook
+(if (null window-size-change-functions)
+    (setq window-size-change-functions '(highlight-global-update-hl-fixup))
+  (add-to-list 'window-size-change-functions 'highlight-global-update-hl-fixup))
+
+;;;###autoload
+(defun highlight-global-hl-frame-toggle ()
   (interactive)
-  (let* ((thing-to-highlight (get-thing-to-highlight))
+  (let* ((thing-to-highlight (highlight-global-get-thing-to-highlight))
          (hi nil)
          (face nil))
     (if (stringp thing-to-highlight)
         (progn
-          (setq hi (check-whether-highlighted thing-to-highlight))
+          (setq hi (highlight-global-check-whether-highlighted thing-to-highlight))
           ;; toogle highlight, 2 cases
           ;; 1) thing already unlighlight and stored in list, unhighight it
           ;; 2) new highlight, highlight it and add it to list
           (if hi
               ;; 1) toogle off
               ;;    1. delete item from global-list && update timestamp
-              ;;    2. set new-unhighlight and unhighight each window
+              ;;    2. set highlight-global-new-unhighlight and unhighight each window
               (progn
-                (setq new-unhighlight hi)
-                (release-face (cdr new-unhighlight))
-                (setq global-highlight-list
-                      (delete new-unhighlight global-highlight-list))
-                (setq global-highlight-list-update-timestamp (float-time))
-                (walk-windows 'unhighlight-window))
+                (setq highlight-global-new-unhighlight hi)
+                (highlight-global--release-face (cdr highlight-global-new-unhighlight))
+                (setq highlight-global-hl-list
+                      (delete highlight-global-new-unhighlight highlight-global-hl-list))
+                (setq highlight-global-hl-list-update-timestamp (float-time))
+                (walk-windows 'highlight-global-unhl-window))
             ;; 2) new highlight
             (progn
-              (setq new-highlight (cons thing-to-highlight (find-and-use-face)))
-              (setq global-highlight-list (cons new-highlight global-highlight-list))
-              (setq global-highlight-list-update-timestamp (float-time))
-              (walk-windows 'highlight-window))))
-      (message "No vaidate region, or no validate symbol under cursor!"))))
+              (setq highlight-global-new-highlight
+                    (cons thing-to-highlight (highlight-global--find-and-use-face)))
+              (setq highlight-global-hl-list
+                    (cons highlight-global-new-highlight highlight-global-hl-list))
+              (setq highlight-global-hl-list-update-timestamp (float-time))
+              (walk-windows 'highlight-global-hl-window))))
+      (message "No valid region, or no valid symbol under cursor!"))))
 
-(defun highlight-update-current-buffer ()
-  "Update a buffer's highlight to be consistent with global
-highlight"
-  (if (<= buffer-highlight-list-update-timestamp
-          global-highlight-list-update-timestamp)
-      (if (null global-highlight-list)      ; clear buffer
-          ;; 1) global null
-          (progn
-            (dolist (item buffer-highlight-list)
-              (font-lock-remove-keywords
-               nil
-               `((,(car item) 0 ,(cdr item) prepend)))
-              (font-lock-fontify-buffer))
-            (setq buffer-highlight-list-update-timestamp (float-time))
-            (setq buffer-highlight-list nil))
-        ;; 2) globla is not null, now update local to global
-        (progn
-          ;; (message "Updating buffer : %s" (current-buffer))
-          ;; 2.1) iterate buffer-list to delete
-          (dolist (item buffer-highlight-list)
-            (if (not (member item global-highlight-list))
-                (progn
-                  ;; `((,(car new-highlight) 0 ,(cdr new-highlight) prepend))
-                  ;; (list (car item))
-                  (font-lock-remove-keywords
-                   nil
-                   `((,(car item) 0 ,(cdr item) prepend)))
-                  (font-lock-fontify-buffer)
-                  (setq buffer-highlight-list
-                        (delete item buffer-highlight-list)))))
-          ;; 2.2) iterate global-list to add
-          (dolist (item global-highlight-list)
-            (if (not (member item buffer-highlight-list))
-                (progn
-                  (font-lock-add-keywords
-                   nil
-                   `((,(car item) 0 ,(cdr item) prepend)) 'append)
-                  (font-lock-fontify-buffer)
-                  (push item buffer-highlight-list))))
-          (setq buffer-highlight-list-update-timestamp (float-time)))
-        ;; (message "no need to update : %s" (current-buffer))
-        )))
+;;;###autoload
+(defun highlight-global-clear-hl-frame ()
+  "Clear all highlights in all windows."
+  (interactive)
+  (walk-windows 'highlight-global-clear-highlight-window)
+  (setq highlight-global-hl-list nil)
+  (highlight-global--clear-all-faces)
+  (setq highlight-global-hl-list-update-timestamp (float-time)))
 
-;; Force to update highlights on current frame, call this function
-;; will update highlights in every window within current frame
-(defun force-highlight-frame ()
+(defun highlight-global-force-hl-frame ()
+  "Force to update highlights in every window in the current frame."
   (interactive)
   (save-excursion
     (walk-windows #'(lambda (win)
                       (select-window win)
-                      (highlight-update-current-buffer)))))
+                      (highlight-global-update-current-buffer-hl)))))
 
-;; Automatically update new buffer's highlights when any windows on
-;; current frame changed. This will make buffers that to be showned
-;; because of window splitting alway has highlights updated to date.
-(defun update-highlight-fixup (frame)
-  (force-highlight-frame))
-
-;; register the on-the-fly highlight-list updating strategy to
-;; window-size-change-functions hook
-(if (null window-size-change-functions)
-    (setq window-size-change-functions '(update-highlight-fixup))
-  (add-to-list 'window-size-change-functions 'update-highlight-fixup))
 
 (provide 'highlight-global)
 


### PR DESCRIPTION
Hi,

First of all, thank you for pointing me to this package about 2 years back :)

Over time, as I learnt elisp, I slowly started understanding what this package did. The only issue I found was that if I had any symbols highlighted, I wouldn't be able to see the colors in the *Colors* buffer that's opens on doing `M-x list-colors-display`. Later I saw the similar issue when using packages that pop up their own custom highlighted windows, like `hydra` and `which-key`.

So the main change in this PR is to allow blacklisting certain buffers so that highlight update does not happen in those.

Apart from that main change:
- I removed `(setq hi-lock-file-patterns-policy 'never)`. Because that is a defcustom variable and having that in this package prevented me to use the file-based hi-lock patterns.
- Typo fixes.
- Massive refactoring to stick to current elisp convention that all variables and functions in a package should begin with the package name. Wherever the name became too long because of the "highlight" string in it, I took the liberty of truncating the second occurrence of "highlight" in the same variable/defun name with "hl".
- Rearrangment of the code so that all defvars are at the top.
- Added `;;;###autoload` cookies for the package-entry functions.
- Removed `(interactive)` from `force-highlight-frame` ( _now_ `highlight-global-force-hl-frame`).
